### PR TITLE
fix many typos with GNU aspell

### DIFF
--- a/Arithmetic Functions.ipynb
+++ b/Arithmetic Functions.ipynb
@@ -149,7 +149,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Monadic `+` and `×` are designed for complex numbers. `+` gives the complex conjuigate. `×` gives a complex number with magnitude 1 (unless it is applied to `0`) in the direction of its argument. For real numbers, `+` has no effect, and `×` gives the sign of its argument."
+    "Monadic `+` and `×` are designed for complex numbers. `+` gives the complex conjugate. `×` gives a complex number with magnitude 1 (unless it is applied to `0`) in the direction of its argument. For real numbers, `+` has no effect, and `×` gives the sign of its argument."
    ]
   },
   {

--- a/Arrays.ipynb
+++ b/Arrays.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "Throughout this lesson there are snippets of code as examples. You are encouraged to edit and experiment with these – it will greatly improve your understanding.\n",
     "\n",
-    "All data in APL resides in arrays. An array is a rectangular collection of numbers, characters and arrays, arranged along zero or more axes. Numbers and characters are 0 dimensional arrays, and are refered to as scalars. Characters are in single quotes.\n",
+    "All data in APL resides in arrays. An array is a rectangular collection of numbers, characters and arrays, arranged along zero or more axes. Numbers and characters are 0 dimensional arrays, and are referred to as scalars. Characters are in single quotes.\n",
     "\n",
     "Creating a 1-dimensional array is very simple: just write the elements next to each other, separated by spaces. This syntax works for any data that you want in the array: numbers, characters, other arrays (etc.)\n",
     "\n",
@@ -570,7 +570,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The depth of the previous example is `¯3` because the `'A'` in `'APL'` is at a depth of 3 and the depth of te array is uneven."
+    "The depth of the previous example is `¯3` because the `'A'` in `'APL'` is at a depth of 3 and the depth of the array is uneven."
    ]
   },
   {
@@ -740,7 +740,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note the identity: `X ≡ ⍴ (X ⍴ A)`. After reshaping an array with `X`, it's shape will allways be `X`."
+    "Note the identity: `X ≡ ⍴ (X ⍴ A)`. After reshaping an array with `X`, it's shape will always be `X`."
    ]
   },
   {

--- a/Conway's Game of Life.ipynb
+++ b/Conway's Game of Life.ipynb
@@ -510,7 +510,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we've built an expression which produces the next generation for any boolean matrix `R`.  Let's turn this into a function by enclosing it in curly braces `{` `}` and using the formal paramter `⍵<` in place of `R`.  We'll call this function `life`."
+    "Now we've built an expression which produces the next generation for any boolean matrix `R`.  Let's turn this into a function by enclosing it in curly braces `{` `}` and using the formal parameter `⍵<` in place of `R`.  We'll call this function `life`."
    ]
   },
   {
@@ -547,7 +547,7 @@
    "source": [
     "Displays the first 3 generations for `R`.\n",
     "\n",
-    "Now, we can generalize that by writing a function `gen` which uses the power operator `⍣` to apply `life` to the power of the left argument to the right argument."
+    "Now, we can generalise that by writing a function `gen` which uses the power operator `⍣` to apply `life` to the power of the left argument to the right argument."
    ]
   },
   {

--- a/Functions.ipynb
+++ b/Functions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A function can applied to data in two ways: **dyadically** or **monadically**. That is, a function can be applied to either one or two arguments. Most primitve functions have both a dyadic and a monadic definition. For example `-`, when applied dyadically is subtract, and when applied monadically is negate."
+    "A function can applied to data in two ways: **dyadically** or **monadically**. That is, a function can be applied to either one or two arguments. Most primitive functions have both a dyadic and a monadic definition. For example `-`, when applied dyadically is subtract, and when applied monadically is negate."
    ]
   },
   {
@@ -152,7 +152,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When a scalar function is applied dyadically, the scalars are paired up between the two arrarys and the function is applied between the pairs. If the shapes of the arguments do not match up, an error is reported."
+    "When a scalar function is applied dyadically, the scalars are paired up between the two arrays and the function is applied between the pairs. If the shapes of the arguments do not match up, an error is reported."
    ]
   },
   {
@@ -361,7 +361,7 @@
     "\n",
     "`-` is negate\n",
     "\n",
-    "`÷` is reciprical\n",
+    "`÷` is reciprocal\n",
     "\n",
     "`+` is complex-conjugate (Acts as identity for real numbers)\n",
     "\n",
@@ -493,7 +493,7 @@
    "source": [
     "## Dfns\n",
     "\n",
-    "A dfn (dynamic-function) is an APL expression enclosed in braces (`{}`) where the left and right arguments are refered to by `⍺` and `⍵` (the leftmost and rightmost characters in the greek alphabet) respectively. For a monadic function, only `⍵` is used."
+    "A dfn (dynamic-function) is an APL expression enclosed in braces (`{}`) where the left and right arguments are referred to by `⍺` and `⍵` (the leftmost and rightmost characters in the Greek alphabet) respectively. For a monadic function, only `⍵` is used."
    ]
   },
   {
@@ -807,7 +807,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Longer tacit functions are often refered to as trains, where each car is either a function or an array. We'll start by going over monadic trains.\n",
+    "Longer tacit functions are often referred to as trains, where each car is either a function or an array. We'll start by going over monadic trains.\n",
     "\n",
     "A two-train `f g` is called an atop. `(f g) X` is equivalent to `f (g X)`. f is evaluated *atop* the result of g."
    ]
@@ -1058,7 +1058,7 @@
     "\n",
     "For example `(p q r s) X` becomes `(p (q r s)) X` which becomes `p ((q r s) X)` which finally evaluates to `p ((q X) r (s X))`\n",
     "\n",
-    "In the same way `X (p q r s t) Y` is equivilent to `(X p Y) q ((X r Y) s (X t Y))`"
+    "In the same way `X (p q r s t) Y` is equivalent to `(X p Y) q ((X r Y) s (X t Y))`"
    ]
   },
   {

--- a/Grading and Sorting.ipynb
+++ b/Grading and Sorting.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is no sort primitive in APL, although sorting can be easily acheived with the use of `⍋` (grade up) or `⍒` (grade down).\n",
+    "There is no sort primitive in APL, although sorting can be easily achieved with the use of `⍋` (grade up) or `⍒` (grade down).\n",
     "\n",
     "`⍋` takes an array and returns the indices of the major cells in ascending order. From the least major cell to the greatest major cell. It is easiest to understand with an example:"
    ]
@@ -119,7 +119,7 @@
    "source": [
     "So the first is row 2 (`1 8`) then row 1 (`2 7`) then row 3 (`2 8`). This is a lexicographic ordering - The cells are compared item by item, until there is a difference.\n",
     "\n",
-    "Characters are compared using their unicode codepoints:"
+    "Characters are compared using their Unicode codepoints:"
    ]
   },
   {
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To sort an array of any rank, one can defnine a function:"
+    "To sort an array of any rank, one can define a function:"
    ]
   },
   {
@@ -227,7 +227,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`⍒` is grade down. It bahaves in the same way as `⍋` but grade in descending order."
+    "`⍒` is grade down. It behaves in the same way as `⍋` but grade in descending order."
    ]
   },
   {
@@ -373,7 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first element (`4`) is the third smallest element, the second element (`6`) is the fifth smallest, and so on. It is fairly common to use `⍋⍋` to *noramalise* a vector, `V`, to a permutation of `⍳≢V` which has the same ordering as `V`."
+    "The first element (`4`) is the third smallest element, the second element (`6`) is the fifth smallest, and so on. It is fairly common to use `⍋⍋` to *normalise* a vector, `V`, to a permutation of `⍳≢V` which has the same ordering as `V`."
    ]
   },
   {

--- a/Rank and Depth.ipynb
+++ b/Rank and Depth.ipynb
@@ -133,7 +133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When mixing a vector of higher rank arrays, the result will have the a rank one more than the array of greatest rank in the argument. Mixing a vector of matrices will create a 3 dimenional array where each matrix is a plane."
+    "When mixing a vector of higher rank arrays, the result will have the a rank one more than the array of greatest rank in the argument. Mixing a vector of matrices will create a 3 dimensional array where each matrix is a plane."
    ]
   },
   {
@@ -377,7 +377,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the argument is a vector `V`, it's rank is 1. Spliting it will result in an array of shape `⍬` whose contents have the shape of `V`; a scalar that itself contains a vector. These are known as enclosed vectors or, more generally, nested scalars."
+    "If the argument is a vector `V`, it's rank is 1. Splitting it will result in an array of shape `⍬` whose contents have the shape of `V`; a scalar that itself contains a vector. These are known as enclosed vectors or, more generally, nested scalars."
    ]
   },
   {
@@ -430,7 +430,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Numbers and characters are known as simple scalars, because their depth is 0. Spliting a simple scalar does nothing, the result is the argument itself. However, spliting nested scalars increases their (absolute) depth by 1."
+    "Numbers and characters are known as simple scalars, because their depth is 0. Splitting a simple scalar does nothing, the result is the argument itself. However, splitting nested scalars increases their (absolute) depth by 1."
    ]
   },
   {
@@ -617,7 +617,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is useful in conjuction with scalar functions. Or any function that treat scalars differently."
+    "This is useful in conjunction with scalar functions. Or any function that treat scalars differently."
    ]
   },
   {
@@ -668,7 +668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, `1 2 3` is added to each of `4 5 6` seperately."
+    "Here, `1 2 3` is added to each of `4 5 6` separately."
    ]
   },
   {

--- a/Reduce and Scan.ipynb
+++ b/Reduce and Scan.ipynb
@@ -461,7 +461,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similaraly `\\` also has a twin `⍀` who behaves as you might expect. Scan on first axis."
+    "Similarly `\\` also has a twin `⍀` who behaves as you might expect. Scan on first axis."
    ]
   },
   {

--- a/Sudoku Solver.ipynb
+++ b/Sudoku Solver.ipynb
@@ -546,7 +546,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Abstracting this as a functon of **rcb 4 4**:\n"
+    "Abstracting this as a function of **rcb 4 4**:\n"
    ]
   },
   {
@@ -1029,7 +1029,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using our **avl** function to generate the vector of avaliable plays:\n"
+    "Using our **avl** function to generate the vector of available plays:\n"
    ]
   },
   {

--- a/lookup without replacement.ipynb
+++ b/lookup without replacement.ipynb
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To solve this we need the second argument of each `⍳` to have the same number of each element when labelling both **L** and **R**. The easiest way to do this is with `L⍪R` and `R⍪L`. `⍪` is used instead of `,` so that the method can be used for higher rank arrarys."
+    "To solve this we need the second argument of each `⍳` to have the same number of each element when labelling both **L** and **R**. The easiest way to do this is with `L⍪R` and `R⍪L`. `⍪` is used instead of `,` so that the method can be used for higher rank arrays."
    ]
   },
   {
@@ -375,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Person number 1 gets seat 3, person number 3 gets seat 7, and so on. Peaple  8 and 12 however cannot get a seat, because all of the seats of their type have been allocated already. This is indicated by the result `12` which is out of the bounds of plane (length-11)."
+    "Person number 1 gets seat 3, person number 3 gets seat 7, and so on. People  8 and 12 however cannot get a seat, because all of the seats of their type have been allocated already. This is indicated by the result `12` which is out of the bounds of plane (length-11)."
    ]
   }
  ],

--- a/working introduction/01 - a) Names and Expressions.ipynb
+++ b/working introduction/01 - a) Names and Expressions.ipynb
@@ -367,7 +367,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The purpose of any specific example is to provide a basis for discovering the idea of the general case. Thus the example `1.12*3` should suggest that any pair of numbers ay be used with the power function denoted by the star."
+    "The purpose of any specific example is to provide a basis for discovering the idea of the general case. Thus the example `1.12*3` should suggest that any pair of numbers may be used with the power function denoted by the star."
    ]
   },
   {

--- a/working introduction/05 - e) APL Errors.ipynb
+++ b/working introduction/05 - e) APL Errors.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "value←'priceless'\n",
-    "balue"
+    "value"
    ]
   },
   {

--- a/working introduction/07 - f) More characters, Names, and Structure.ipynb
+++ b/working introduction/07 - f) More characters, Names, and Structure.ipynb
@@ -260,7 +260,7 @@
    "source": [
     "Individual characters and numbers are also arrays, but arrays with no dimensions, and thus with no lengths in their shape vectors. Arrays which have no dimensions are known as **scalars**.\n",
     "\n",
-    "The shape of a scalar is an **empty vector**. An empty vector has a length (of 0), but contains no elements, while a scalar contains onelement, but has no length."
+    "The shape of a scalar is an **empty vector**. An empty vector has a length (of 0), but contains no elements, while a scalar contains one element, but has no length."
    ]
   },
   {

--- a/working introduction/09 - g) Order of Evaluation.ipynb
+++ b/working introduction/09 - g) Order of Evaluation.ipynb
@@ -56,6 +56,7 @@
    "source": [
     "If parentheses were the only way to specify the order of evaluation, complex expressions would become unreadable tangles of parentheses within parentheses. To simplify writing and reading of code, other rules are needed. APL has one simple, primary rule for evaluation of expressions: Except as modified by parentheses, evaluation proceeds from right to left.\n",
     "\n",
+C
     "Put another way, each function’s right argument is the result of the entire expression to its right (up to an unmatched closing parenthesis) and its left argument -- if it has one -- is the single value to its left, which may be a parenthesized expression or a vector, but cannot be a function."
    ]
   },

--- a/working introduction/12 - j) Select and Locate.ipynb
+++ b/working introduction/12 - j) Select and Locate.ipynb
@@ -886,7 +886,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "∪'tattletale'  ⍝ Uniqe elements"
+    "∪'tattletale'  ⍝ Unique elements"
    ]
   },
   {

--- a/working introduction/16 - n) Decisions and “Canonical” Function Definition.ipynb
+++ b/working introduction/16 - n) Decisions and “Canonical” Function Definition.ipynb
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In canonical functions the first line, or **header**, defines function name, the funciton’s syntax, and all local names. In the above example the function name is `SumParity_c`. It takes a single (right) argument, which is identified by the **local** name `arg`. The assignment arrow indicates that it returns a result, which is identified by the local name `r`. Unlike in dynamic functions, assignment to a name within a canonical function doesn’t automatically localize it. Instead, names are made local by listing them in the right-hand side of the header, preceding each with a semicolon. This has been done with the variable name `t` in the above function."
+    "In canonical functions the first line, or **header**, defines function name, the function's syntax, and all local names. In the above example the function name is `SumParity_c`. It takes a single (right) argument, which is identified by the **local** name `arg`. The assignment arrow indicates that it returns a result, which is identified by the local name `r`. Unlike in dynamic functions, assignment to a name within a canonical function doesn’t automatically localize it. Instead, names are made local by listing them in the right-hand side of the header, preceding each with a semicolon. This has been done with the variable name `t` in the above function."
    ]
   },
   {

--- a/working introduction/Introductory Course.ipynb
+++ b/working introduction/Introductory Course.ipynb
@@ -374,7 +374,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The purpose of any specific example is to provide a basis for discovering the idea of the general case. Thus the example `1.12*3` should suggest that any pair of numbers ay be used with the power function denoted by the star."
+    "The purpose of any specific example is to provide a basis for discovering the idea of the general case. Thus the example `1.12*3` should suggest that any pair of numbers may be used with the power function denoted by the star."
    ]
   },
   {
@@ -1176,7 +1176,7 @@
    "outputs": [],
    "source": [
     "value←'priceless'\n",
-    "balue"
+    "value"
    ]
   },
   {


### PR DESCRIPTION
Used `for i in *; do aspell check --dont-backup -l en_GB "$i"; done;`
This should fix most of them.